### PR TITLE
Instrumented via Jaeger, removed vmware.log code

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,4 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "genebean/centos-7-docker-ce"
+  config.vm.network "forwarded_port", guest: 16686, host: 16686
 end

--- a/getorphanedvms.py
+++ b/getorphanedvms.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This module demonstrates how to find virtual machines that
 exist on a datastore, but are not part of the inventory.
@@ -15,27 +15,26 @@ Example:
       $./getorphanedvms.py -s 10.90.2.10 -u vcenter.svc -p password
 """
 
-from pyVim.connect import SmartConnect
-from pyVim.connect import Disconnect
-from pyVmomi import vmodl
-from pyVmomi import vim
+
 import argparse
 import atexit
-from datetime import datetime
-from datetime import timedelta
+from lib.tracing import init_tracer
+from opentracing_instrumentation.request_context import get_current_span, span_in_context
 import pprint
+from pyVim.connect import Disconnect
+from pyVim.connect import SmartConnect
+from pyVmomi import vmodl
+from pyVmomi import vim
 import requests
+import time
 from urllib.parse import urljoin
 from urllib.parse import urlsplit
 
+TRACER = None
 VMX_PATH = []
 DS_VM = {}
 INV_VM = []
-
-# dates used for comparisons
-TODAY = datetime.now()
-DATE_IN_PAST = None
-
+UNREGISTERED_VMS = []
 
 def get_args():
     """
@@ -64,92 +63,109 @@ def get_args():
     parser.add_argument(
         '--datastore', required=True, action='store',
         help='The datastore to search')
-    parser.add_argument(
-        '--days', type=int, default=2, action='store',
-        help="VM's with activity in their log more recent than X days will be ignored."
-    )
     args = parser.parse_args()
     return args
-
 
 def find_vmx(dsbrowser, dsname, datacenter, fulldsname):
     """
     function to search for VMX files on any datastore that is passed to it
     """
-    args = get_args()
-    search = vim.HostDatastoreBrowserSearchSpec()
-    search.matchPattern = "*.vmx"
-    search_ds = dsbrowser.SearchDatastoreSubFolders_Task(dsname, search)
-    while search_ds.info.state != "success":
-        pass
-    # results = search_ds.info.result
-    # print(results)
+    with TRACER.start_span('find-vmx') as span:
+        span.set_tag('datacenter', datacenter)
+        span.set_tag('datastore-name', fulldsname)
+        args = get_args()
+        search = vim.HostDatastoreBrowserSearchSpec()
+        search.matchPattern = "*.vmx"
+        search_ds = dsbrowser.SearchDatastoreSubFolders_Task(dsname, search)
+        while search_ds.info.state != "success":
+            pass
+        # results = search_ds.info.result
+        # print(results)
 
-    for search_result in search_ds.info.result:
-        dsfolder = search_result.folderPath
-        for found_file in search_result.file:
-            try:
-                dsfile = found_file.path
-                vmfold = dsfolder.split("]")
-                vmfold = vmfold[1]
-                vmfold = vmfold[1:]
-                vmxurl = "https://%s/folder/%s%s?dcPath=%s&dsName=%s" % \
-                         (args.host, vmfold, dsfile, datacenter, fulldsname)
-                VMX_PATH.append(vmxurl)
-                # print(vmxurl)
-            except Exception as e:
-                print("Caught exception : " + str(e))
-                return -1
+        for search_result in search_ds.info.result:
+            dsfolder = search_result.folderPath
+            for found_file in search_result.file:
+                try:
+                    dsfile = found_file.path
+                    vmfold = dsfolder.split("]")
+                    vmfold = vmfold[1]
+                    vmfold = vmfold[1:]
+                    vmxurl = "https://%s/folder/%s%s?dcPath=%s&dsName=%s" % \
+                            (args.host, vmfold, dsfile, datacenter, fulldsname)
+                    VMX_PATH.append(vmxurl)
+                    # print(vmxurl)
+                except Exception as e:
+                    print("Caught exception : " + str(e))
+                    return -1
 
-def examine_vmx(dsname):
+def get_and_parse_vmx_file(dsname, vmx_file, username, password):
     """
     function to download any vmx file passed to it via the datastore browser
     and find the 'vc.uuid' and 'displayName'
     """
-    args = get_args()
-    try:
-        for file_vmx in VMX_PATH:
-            # print(file_vmx)
-
-            username = args.user
-            password = args.password
-            log_url = urljoin(file_vmx, 'vmware.log') + '?' + urlsplit(file_vmx).query
-            r = requests.get(log_url, auth=(username, password))
+    root_span = get_current_span()
+    with TRACER.start_span('get-and-parse-vmx-file', child_of=root_span) as span:
+        try:
+            r = requests.get(vmx_file, auth=(username, password))
             if r.status_code == requests.codes.ok:
-                logfile = r.text.splitlines()
-                last_line = logfile[-1]
-                log_timestamp = datetime.strptime(last_line.split('|')[0].replace('Z', 'UTC'), "%Y-%m-%dT%H:%M:%S.%f%Z")
-
-                if log_timestamp < DATE_IN_PAST:
-                    # print(log_timestamp.isoformat() + " is before " + DATE_IN_PAST.isoformat())
-
-                    vmxfile = requests.get(file_vmx, auth=(username, password)).text.splitlines()
-                    for line in vmxfile:
-                        if line.startswith("displayName"):
-                            dn = line
-                        elif line.startswith("vc.uuid"):
-                            vcid = line
-                        # print(line)
-
+                span.log_kv({'event': 'downloaded-vmx-file', 'value': vmx_file})
+                vmxfile = r.text.splitlines()
+                vcid = None
+                for line in vmxfile:
+                    # print(line)
+                    if line.startswith("displayName"):
+                        dn = line
+                        newdn = dn.replace('"', "")
+                        newdn = newdn.replace("displayName = ", "")
+                        newdn = newdn.strip("\n")
+                    elif line.startswith("vc.uuid"):
+                        vcid = line
+                if vcid is None:
+                    uuid = 'not-found'
+                    print('No uuid found for ' + newdn)
+                else:
                     uuid = vcid.replace('"', "")
                     uuid = uuid.replace("vc.uuid = ", "")
                     uuid = uuid.strip("\n")
                     uuid = uuid.replace(" ", "")
                     uuid = uuid.replace("-", "")
-                    newdn = dn.replace('"', "")
-                    newdn = newdn.replace("displayName = ", "")
-                    newdn = newdn.strip("\n")
-                    vmfold = file_vmx.split("folder/")
-                    vmfold = vmfold[1].split("/")
-                    vmfold = vmfold[0]
-                    dspath = "%s/%s" % (dsname, vmfold)
-                    tempds_vm = [newdn, dspath]
-                    DS_VM[uuid] = tempds_vm
-                    
-                    # print(newdn + "'s last log entry was " + log_timestamp.isoformat())                    
 
-    except Exception as e:
-        print("Caught exception in examine_vmx function : " + str(e))
+                vmfold = vmx_file.split("folder/")
+                vmfold = vmfold[1].split("/")
+                vmfold = vmfold[0]
+                dspath = "%s/%s" % (dsname, vmfold)
+                tempds_vm = [newdn, dspath]
+                DS_VM[uuid] = tempds_vm
+                span.set_tag('vm-uuid', uuid)
+                span.set_tag('vm-dn', newdn)
+
+                # print(newdn + "'s last log entry was " + log_timestamp.isoformat())
+            else:
+                span.log_kv({'event': 'failed-downloaded-of-vmx-file', 'value': vmx_file})
+        except Exception as e:
+            print("Caught exception in get_and_parse_vmx_file function : " + str(e))
+            print("The file is from " + vmx_file)
+            r = requests.get(vmx_file, auth=(username, password))
+            vmxfile_text = r.text.splitlines()
+            print(vmxfile_text)
+
+def examine_vmx(dsname):
+    """
+    function to loop over vmx files passed to it via the datastore browser
+    """
+    with TRACER.start_span('examine-vmx') as span:
+        span.set_tag('datastore-name', dsname)
+        args = get_args()
+        try:
+            for file_vmx in VMX_PATH:
+                # print(file_vmx)
+                username = args.user
+                password = args.password
+                with span_in_context(span):
+                    get_and_parse_vmx_file(dsname, file_vmx, username, password)                  
+
+        except Exception as e:
+            print("Caught exception in examine_vmx function : " + str(e))
 
 def getvm_info(vm, depth=1):
     """
@@ -157,51 +173,53 @@ def getvm_info(vm, depth=1):
     into a folder with depth protection
     from the getallvms.py script from pyvmomi from github repo
     """
-    maxdepth = 10
+    root_span = get_current_span()
+    with TRACER.start_span('getvm-info', child_of=root_span) as span:
+        maxdepth = 10
 
-    # if this is a group it will have children. if it does,
-    # recurse into them and then return
+        # if this is a group it will have children. if it does,
+        # recurse into them and then return
 
-    if hasattr(vm, 'childEntity'):
-        if depth > maxdepth:
+        if hasattr(vm, 'childEntity'):
+            if depth > maxdepth:
+                return
+            vmlist = vm.childEntity
+            for c in vmlist:
+                with span_in_context(span):
+                    getvm_info(c, depth+1)
             return
-        vmlist = vm.childEntity
-        for c in vmlist:
-            getvm_info(c, depth+1)
-        return
-    if hasattr(vm, 'CloneVApp_Task'):
-        vmlist = vm.vm
-        for c in vmlist:
-            getvm_info(c)
-        return
+        if hasattr(vm, 'CloneVApp_Task'):
+            vmlist = vm.vm
+            for c in vmlist:
+                with span_in_context(span):
+                    getvm_info(c)
+            return
 
-    try:
-        uuid = vm.config.instanceUuid
-        uuid = uuid.replace("-", "")
-        INV_VM.append(uuid)
-    except Exception as e:
-        print("Caught exception : " + str(e))
-        return -1
+        try:
+            uuid = vm.config.instanceUuid
+            uuid = uuid.replace("-", "")
+            INV_VM.append(uuid)
+            span.set_tag('vm-uuid', uuid)
+        except Exception as e:
+            print("Caught exception : " + str(e))
+            return -1
 
 def find_match(uuid):
     """
     function takes vc.uuid from the vmx file and the instance uuid from
     the inventory VM and looks for match if no match is found
-    it is printed out.
+    it is added to the UNREGISTERD_VMS list.
     """
-    a = 0
-    for temp in INV_VM:
-        if uuid == temp:
-            a = a+1
-    if a < 1:
-        print(DS_VM[uuid])
-
-def update_date_in_past(number_of_days):
-    """
-    function to update teh DATE_IN_PAST global variable
-    """
-    global DATE_IN_PAST
-    DATE_IN_PAST = TODAY - timedelta(days=number_of_days)
+    root_span = get_current_span()
+    with TRACER.start_span('find-match', child_of=root_span) as span:
+        span.set_tag('vm-uuid', uuid)
+        a = 0
+        for temp in INV_VM:
+            if uuid == temp:
+                a = a+1
+        if a < 1:
+            UNREGISTERED_VMS.append(DS_VM[uuid])
+            # print(DS_VM[uuid])
 
 def updatevmx_path():
     """
@@ -215,79 +233,113 @@ def main():
     function runs all of the other functions. Some parts of this function
     are taken from the getallvms.py script from the pyvmomi gihub repo
     """
+    global TRACER
+    TRACER = init_tracer('vmware-orphanage')
     args = get_args()
-    update_date_in_past(args.days)
     try:
-        si = None
-        try:
-            si = SmartConnect(host=args.host,
-                              user=args.user,
-                              pwd=args.password,
-                              port=int(args.port))
-        except IOError as e:
-            pass
+        with TRACER.start_span('connect-to-vcenter') as span:
+            si = None
+            try:
+                si = SmartConnect(host=args.host,
+                                user=args.user,
+                                pwd=args.password,
+                                port=int(args.port))
+            except IOError as e:
+                print("Caught exception : " + str(e))
+                return -1
 
-        if not si:
-            print("Could not connect to the specified host using " \
-                  "specified username and password")
-            return -1
+            if si:
+                span.log_kv({'event': 'connected-to-vcenter', 'value': args.host})
+                atexit.register(Disconnect, si)
+            else:
+                print("Could not connect to the specified host using " \
+                    "specified username and password")
+                return -1
 
-        atexit.register(Disconnect, si)
+        with TRACER.start_span('get-info-from-vcenter') as span:
+            content = si.RetrieveContent()
 
-        content = si.RetrieveContent()
+            datacenters = content.rootFolder.childEntity
+            target_datacenter = None
+            for dc in datacenters:
+                if dc.name == args.datacenter:
+                    target_datacenter = dc
+                    break
+            if target_datacenter == None:
+                print("Couldn't find a datacenter named '%s'" % args.datacenter)
+                return -1
 
-        datacenters = content.rootFolder.childEntity
-        target_datacenter = None
-        for dc in datacenters:
-            if dc.name == args.datacenter:
-                target_datacenter = dc
-                break
-        if target_datacenter == None:
-            print("Couldn't find a datacenter named '%s'" % args.datacenter)
-            return -1
+            datastores = target_datacenter.datastore
+            target_datastore = None
+            for ds in datastores:
+                if ds.summary.name == args.datastore:
+                    target_datastore = ds
+                    break
+            if target_datastore == None:
+                print("Couldn't find a datastore named '%s'" % args.datastore)
+                return -1
 
-        datastores = target_datacenter.datastore
-        target_datastore = None
-        for ds in datastores:
-            if ds.summary.name == args.datastore:
-                target_datastore = ds
-                break
-        if target_datastore == None:
-            print("Couldn't find a datastore named '%s'" % args.datastore)
-            return -1
-
-        vmfolder = target_datacenter.vmFolder
-        vmlist = vmfolder.childEntity
-        dsvmkey = []
+            vmfolder = target_datacenter.vmFolder
+            vmlist = vmfolder.childEntity
+            dsvmkey = []
 
         
-        find_vmx(target_datastore.browser, "[%s]" % target_datastore.summary.name, target_datacenter.name,
-                    target_datastore.summary.name)
+        find_vmx(target_datastore.browser,
+                 "[%s]" % target_datastore.summary.name,
+                 target_datacenter.name,
+                 target_datastore.summary.name)
+
+        vmx_count = len(VMX_PATH)
         examine_vmx(target_datastore.summary.name)
         updatevmx_path()
 
         # each VM found in the inventory is passed to the getvm_info
         # function to get it's instanceuuid
 
-        for vm in vmlist:
-            getvm_info(vm)
+        with TRACER.start_span('get-vm-uuids') as span:
+            with span_in_context(span):
+                for vm in vmlist:
+                    getvm_info(vm)
         
+        # each key from the DS_VM hashtable is added to a separate
+        # list for comparison later
+
+        for a in DS_VM.keys():
+            dsvmkey.append(a)
+
         # each uuid in the dsvmkey list is passed to the find_match
         # function to look for a match
+        with TRACER.start_span('find-unregistered-vms') as span:
+            with span_in_context(span):
+                for uuid in dsvmkey:
+                    find_match(uuid)
 
         print("The following virtual machine(s) do not exist in the " \
               "inventory, but exist on a datastore " \
               "(Display Name, Datastore/Folder name):")
-        for match in dsvmkey:
-            find_match(match)
+        print("")
+        for orphan in UNREGISTERED_VMS:
+            print(orphan)
+        
+        print("")
+        print("VMX files found: " + str(vmx_count))
+        print("VM's in inventory: " + str(len(INV_VM)))
+        print("Orphans found: " + str(len(UNREGISTERED_VMS)))
 
         Disconnect(si)
+
+        # yield to IOLoop to flush the spans
+        time.sleep(2)
     except vmodl.MethodFault as e:
         print("Caught vmodl fault : " + e.msg)
         return -1
     except Exception as e:
         print("Caught exception : " + str(e))
         return -1
+
+    # yield to IOLoop to flush the spans
+    time.sleep(2)
+    TRACER.close()
 
     return 0
 

--- a/lib/tracing.py
+++ b/lib/tracing.py
@@ -1,0 +1,21 @@
+import logging
+from jaeger_client import Config
+
+def init_tracer(service):
+    logging.getLogger('').handlers = []
+    logging.basicConfig(format='%(message)s', level=logging.WARNING)
+
+    config = Config(
+        config={ # usually read from some yaml config
+            'sampler': {
+                'type': 'const',
+                'param': 1,
+            },
+            'logging': True,
+            'reporter_batch_size': 1,
+        },
+        service_name=service,
+    )
+
+    # this call also sets opentracing.tracer
+    return config.initialize_tracer()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
+jaeger-client>=3.11,<4
+opentracing_instrumentation>=2.4,<3
 pyvmomi
 requests


### PR DESCRIPTION
Aparantly some logs can be north of 8GB... that's too big to deal with
here so using vmware.log ended up being a no-go.

TODO:
- [ ] fix "trace-without-root-span" related to `find_match`
- [ ] update README.md